### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ We have slightly modified the circuit from last branch to accomodate the usecase
 * Generating a verifier contract from the circuit. This contract will help us in verification of the generated proof. You can do this by running the following command from `circuits/` directory
 
 ```bash
-nargo run codegen-verifier
+nargo codegen-verifier
 ```
 
 Post the execution of this step, you will notice a newly generated [contract](circuits/contract/circuits/plonk_vk.sol).


### PR DESCRIPTION
I removes the `run` in the `nargo codegen-verifier` command  
it generated the error...

![image](https://github.com/ZKCamp/noir-voting/assets/69092079/1f0f9696-5c31-410a-800e-8eb4b835cc51)

The command that worked is just `nargo codegen-verifier` ✅
